### PR TITLE
Add root .gitignore for SenseCore services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# IntelliJ IDEA
+.idea/
+*.iml
+*.iws
+*.ipr
+out/
+
+# Java / Spring Boot
+*.class
+*.jar
+*.war
+*.ear
+hs_err_pid*
+replay_pid*
+
+# Maven
+/target/
+
+# Gradle
+/.gradle/
+/build/
+
+# Logs
+*.log
+
+# Angular / Node
+/node_modules/
+/dist/
+/.angular/
+*.tsbuildinfo
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Arduino
+*.hex
+*.elf
+*.bin
+*.map
+*.d
+*.o
+*.obj
+
+# Nginx
+*.pid
+
+# OS
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
### Motivation
- Provide ignore rules for a multi-service repository that contains Java Spring Boot microservices, an Angular frontend, Arduino code, Nginx artifacts, and IntelliJ metadata.
- Prevent accidental commits of build artifacts, dependency folders, and IDE configuration files.
- Keep repository history clean across multiple build tools (`Maven`, `Gradle`, `npm`/`yarn`).

### Description
- Add a root `.gitignore` file containing common IDE, language, and tool artifacts to ignore.
- Include rules for IntelliJ (`.idea/`, `*.iml`), Java/Spring Boot artifacts (`*.class`, `*.jar`, `/target/`, `/build/`), and generic logs.
- Add Node/Angular entries (`/node_modules/`, `/dist/`, `*.tsbuildinfo`) and Arduino build outputs (`*.hex`, `*.elf`, `*.bin`, `*.o`).
- Add Nginx PID ignores and common OS files like `.DS_Store` and `Thumbs.db`.

### Testing
- No automated tests or CI jobs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69653844888c8332984eb9be360a3a14)